### PR TITLE
Create Environment Var Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,32 @@
 # NPM-blackbox-extractor
-Python Script to extract the active Proxy's from the 'Nginx Proxy Manager' using the Database
+Python Script to extract the active Proxies from the 'Nginx Proxy Manager' using the Database
 
-This Script exports the Active Proxy's into an blackbox-exporter-target file, and reloads the Prometheus Config via the API.
-You need to change the Prometheus URL inside the [exporter.py](https://github.com/TheGameProfi/NPM-blackbox-extractor/blob/main/exporter.py#L11) in Line 11, or set `reload_prom` to `False` in Line 12
+This Script exports the Active Proxies into an blackbox-exporter-target file, and can reloads the Prometheus Config via the API.
 
-You also need to change the Blackbox exporter url/ip in [Line 52](https://github.com/TheGameProfi/NPM-blackbox-extractor/blob/main/exporter.py#L52)
+## Configuration
+For Examples of Compose Files see [examples/](examples/)
+
+### Prometheus
+Default it takes the `host.docker.internal:9090`, for that you would need to pass through the docker host:
+```bash
+# Docker run
+docker run -it --add-host=host.docker.internal:host-gateway ...
+```
+```yml
+# Docker Compose
+services:
+  extra_hosts:
+    - "host.docker.internal:host-gateway"
+  ...
+```
+If you have a different Url or behind a Proxy you can change the PrometheusUrl via the Environment Var `prometheusUrl` (with http/https and if the subpath).
+Or if you don't want the Prometheus to be reloaded you can deactivate it by passing the environment Var `reloadProm=False`
+
+For running the Exporter without docker you can either pass the Envs or change it in the [exporter.py](exporter.py#L12)
+
+### Blackbox
+Default the Extractor is using `blackbox:9115` as blackboxUrl to change it pass the env Var `blackboxUrl` without http/https (https not tested).
+Or when running locally you can change it in [Line 15](exporter.py#L15)
 
 ---
 ```text

--- a/examples/oneFile.yml
+++ b/examples/oneFile.yml
@@ -1,0 +1,47 @@
+services:
+  nginxproxy:
+    image: 'jc21/nginx-proxy-manager:latest'
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '81:81'
+      - '443:443'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./npm/data:/data
+      - ./npm/letsencrypt:/etc/letsencrypt
+      
+  host-exporter:
+    image: ghcr.io/thegameprofi/npm-blackbox-extractor
+    environment:
+      - prometheusUrl=http://prometheus:9090/-/reload
+    volumes:
+      - ./npm/data/database.sqlite:/app/data/database.sqlite
+      - ./hosts.json:/app/save/proxy_hosts.json
+      - ./prometheus/http_targets.yml:/app/save/prometheus.yml
+    restart: unless-stopped
+
+  blackbox:
+    image: prom/blackbox-exporter
+    container_name: blackbox
+    volumes:
+      - ./blackbox:/config
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command:
+      - "--config.file=/config/blackbox.yml"
+    restart: unless-stopped
+    
+  monitoring-prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus:/etc/prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--web.enable-lifecycle"
+    restart: unless-stopped
+  

--- a/exporter.py
+++ b/exporter.py
@@ -4,12 +4,13 @@ import yaml
 import time
 import ast
 import requests
+import os
 
 # Path to your SQLite database file
 DB_FILE = '/app/data/database.sqlite'
 
-url = 'http://localhost:9090/-/reload'
-reload_prom = True
+url = os.environ.get("prometheusUrl", "http://host.docker.internal:9090/-/reload")
+reload_prom = os.environ.get("reloadProm", True)
 
 # Path to save JSON file
 JSON_FILE = '/app/save/proxy_hosts.json'

--- a/exporter.py
+++ b/exporter.py
@@ -12,6 +12,8 @@ DB_FILE = '/app/data/database.sqlite'
 url = os.environ.get("prometheusUrl", "http://host.docker.internal:9090/-/reload")
 reload_prom = os.environ.get("reloadProm", True)
 
+blackboxUrl = os.environ.get("blackboxUrl", "blackbox:9115")
+
 # Path to save JSON file
 JSON_FILE = '/app/save/proxy_hosts.json'
 
@@ -50,7 +52,7 @@ def prometheus_config_exporter(targets):
                     },
                     {
                         "target_label": "__address__",
-                        "replacement": "blackbox:9115",
+                        "replacement": blackboxUrl,
                     }
                 ],
             },


### PR DESCRIPTION
This pull request includes several significant updates to the `NPM-blackbox-extractor` project, focusing on improving configuration flexibility and adding Docker Examples. The most important changes include updates to the `README.md` for better documentation, new Docker Compose examples, and modifications to `exporter.py` for environment variable support.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R29): Enhanced documentation with detailed configuration instructions for Prometheus and Blackbox, including Docker run and Docker Compose examples.

Configuration flexibility:

* [`exporter.py`](diffhunk://#diff-6a47d491326e757a5ba57aef793735c4fb425716ab74a7258ac4c78b33c7e598R7-R15): Added support for environment variables to configure `prometheusUrl`, `reloadProm`, and `blackboxUrl`, allowing for more flexible deployment configurations.
* [`exporter.py`](diffhunk://#diff-6a47d491326e757a5ba57aef793735c4fb425716ab74a7258ac4c78b33c7e598L52-R55): Updated the `prometheus_config_exporter` function to use the `blackboxUrl` environment variable for the Blackbox exporter URL.

Docker Examples:

* [`examples/oneFile.yml`](diffhunk://#diff-b74cd70fc83724932f7e0045b6e05d4f2c23df52ab7f41707190619241e5fc16R1-R47): Added a comprehensive Docker Compose example file to facilitate setting up the Nginx Proxy Manager, host exporter, Blackbox exporter, and Prometheus.